### PR TITLE
Remove reference to the word "simple"

### DIFF
--- a/_episodes/02-variables.md
+++ b/_episodes/02-variables.md
@@ -193,7 +193,7 @@ print(ewr_422_yY, 'is', flabadab, 'years old')
 >
 > Draw a table showing the values of the variables in this program
 > after each statement is executed.
-> In simple terms, what do the last three lines of this program do?
+> What do the last three lines of this program do?
 >
 > ~~~
 > x = 1.0


### PR DESCRIPTION
Using the word "simple" in this context can demotivate the learners. The word "simple" is not necessary for the sentence and can be removed.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
